### PR TITLE
Branch segments

### DIFF
--- a/lib/fluent.js
+++ b/lib/fluent.js
@@ -17,7 +17,8 @@
 
   function fluent(segments, handler, extend) {
     var propertySpec = buildPropertySpec(segments),
-      methods = Object.keys(propertySpec);
+      methods = Object.keys(propertySpec),
+      branches;
 
     if (!methods.length) {
       throw new Error('At least one segment is required');
@@ -25,6 +26,12 @@
 
     if (!handler) {
       throw new Error('Parameter handler is required');
+    }
+
+    if (typeof(handler) != 'function') {
+      branches = handler;
+    } else {
+      branches = {};
     }
 
     function updateArgumentsForSegment(segment, withContext, args) {
@@ -45,8 +52,15 @@
         updateArgumentsForSegment(methods[fnIndex], context, arguments);
         var next = {}, nextFn = methods[++fnIndex];
         if (nextFn) {
-          next[nextFn] = fluentFn;
-          return next;
+          if (branches[nextFn]) {
+            for (var branch in branches) {
+              next[branch] = branches.hasOwnProperty(branch) ? branches[branch].bind.apply(branches[branch], [thisArg].concat(context)) : undefined;
+            }
+            return next;
+          } else {
+            next[nextFn] = fluentFn;
+            return next;
+          }
         } else {
           return handler.apply(thisArg, context);
         }

--- a/lib/fluent.js
+++ b/lib/fluent.js
@@ -28,7 +28,7 @@
       throw new Error('Parameter handler is required');
     }
 
-    if (typeof(handler) != 'function') {
+    if (typeof(handler) !== 'function') {
       branches = handler;
     } else {
       branches = {};

--- a/lib/fluent.spec.js
+++ b/lib/fluent.spec.js
@@ -42,6 +42,21 @@ describe('fluent()', function () {
 
     expect(appendTest('ok', 'sure')).to.eql('oksureTest');
   });
+  it('should branch functions', function () {
+    var insertTest = fluent({insertTest: '*', into: '[]', before: '*', after: '*'}, {
+      before: function (value1, array, value2) {
+        array.splice(array.indexOf(value2), 0, value1);
+        return array;
+      },
+      after: function (value1, array, value2) {
+        array.splice(array.indexOf(value2) + 1, 0, value1);
+        return array;
+      }
+    });
+
+    expect(insertTest('is').into(['this', 'awesome']).before('awesome')).to.eql(['this','is','awesome']);
+    expect(insertTest('great').into(['this', 'is']).after('is')).to.eql(['this','is','great']);
+  });
   it('should require at least one segment', function () {
     expect(fluent.bind(undefined, {}, function () {
     })).to.throwException(/At least one segment is required/);

--- a/lib/fluent.spec.js
+++ b/lib/fluent.spec.js
@@ -85,5 +85,20 @@ describe('fluent()', function () {
         expect().fail(method + ' was enumerated');
       }
     });
+    it('should branch functions', function () {
+      var someObj = {};
+
+      fluent({newMethod: '*', yin: '*', yang: '*'}, {
+        yin: function () {
+          return 'yin';
+        },
+        yang: function () {
+          return 'yang';
+        }
+      }, someObj);
+
+      expect(someObj.newMethod().yin()).to.eql('yin');
+      expect(someObj.newMethod().yang()).to.eql('yang');
+    })
   });
 });

--- a/lib/fluent.spec.js
+++ b/lib/fluent.spec.js
@@ -99,6 +99,6 @@ describe('fluent()', function () {
 
       expect(someObj.newMethod().yin()).to.eql('yin');
       expect(someObj.newMethod().yang()).to.eql('yang');
-    })
+    });
   });
 });


### PR DESCRIPTION
Hey! I really liked your blog post re: this project and got interested in tackling the branching feature. Here’s a first stab at it. Only segments at the end of the list segments can be branched. The syntax is as follows:

``` javascript
var insert = fluent({ insert: '*', into: '[]', before: '*', after: '*' }, {
  before: function (value1, array, value2) {
    array.splice(array.indexOf(value2), 0, value1);
    return array;
  },
  after: function (value1, array, value2) {
    array.splice(array.indexOf(value2) + 1, 0, value1);
    return array;
  }
})

insert('is').into(['this', 'awesome']).before('awesome') // ['this', 'is', 'awesome']
insert('great').into(['this', 'is']).after('is') // ['this', 'is', 'great']
```

If `handler` is not a function, it’s presumed to be an object with methods named after the segments that need to be branched. The last segment _not_ to be branched returns a `next` object with methods for each branched segment.

All your old tests pass and I’ve written new tests for the new functionality. Linting passes with a warning (which I’m now realizing makes Travis throw a fit); I’m using a `!=` instead of a `!==`. ~~The comparison I’m making (`typeof(handler) != 'function'`) doesn’t really merit the overhead of strict comparison, I think.~~

**Update:** I learned today that there isn’t much of a performance issue in using strict comparison when the values are of the same type anyway, so I updated the operator to appease Travis.
